### PR TITLE
Remove [fence] entries from areas list

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -99,7 +99,7 @@ def get_spawns():
         area = f.read()
 
     area = area.replace(",", " ").strip("\n")
-    area = area.split("\n")
+    area = [point for point in area.split("\n") if point.find('[') == -1]
     area.append(area[0])
     area = ",".join(area)
     cursor = connection.cursor()


### PR DESCRIPTION
MAD supports geofences in the below format

```
[area1]
lat,lng
lat,lng
lat,lng
[area2]
lat,lng
lat,lng
[area3]
...
```

Setting a `fence.txt` with the above content currently doesn't work, as it tries to pass `[area1]` into the SQL query when working out spawn points.

This PR "works-around" that by filtering the `area` list to omit any entries that contain a `[`. This character won't be present lat/lng pairs therefore will be safe to filter.

I'm not sure if this is the best way to filter, my python is pretty rusty. Does seem to work for me though.