### PR TITLE
Fixes max() arg is an empty sequence

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -177,7 +177,8 @@ def cluster_v1(spawns, final=[]):
         for point in points:
             if spawn.id in point.get_spawn_id():
                 circles.append(point)
-        
+        if len(circles) == 0:
+            continue
         circle = max(circles, key=lambda point: (len(point.get_spawns())))
         for circlespawn in circle.get_spawns():
             circlespawn.done = True


### PR DESCRIPTION
Fixes the below error:

 (most recent call last):
  File "cluster.py", line 198, in <module>
    final = cluster_v1(spawns)
  File "cluster.py", line 181, in cluster_v1
    circle = max(circles, key=lambda point: (len(point.get_spawns())))
ValueError: max() arg is an empty sequence

I have tested this with variations of min_total and min-added of up to 9 and works perfectly.